### PR TITLE
Create GitHub issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,0 +1,61 @@
+name: Bug Report
+description: Something about the `Rx` API is not working as expected.
+title: "[Bug]: "
+labels: ["bug", "untriaged"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Bug reports are very welcome!
+        This template will help gather the information needed to start the review process.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        Please share a clear and concise description of the problem.
+        Include the behavior you expect and the behavior you are actually seeing.
+      placeholder: Describe your issue.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Reproduction Steps
+      description: |
+        Please include minimal steps to reproduce the problem, if possible.
+        This could be a code snippet or a small project setup and the steps to run it.
+        If possible, please avoid including screenshots.
+      placeholder: Reproduction steps (minimal).
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: |
+        Please provide what version of the `Rx` API your issue occurs on.
+        This can be the commit hash, or a release tag.
+    validations:
+      required: true
+  - type: textarea
+    id: regression
+    attributes:
+      label: Regression?
+      description: |
+        Did this work in a previous version of the `Rx` API?
+        If you can, please point to a version in which this feature was functional to help narrow down the problem.
+      placeholder: Leave this field blank if you aren't sure.
+    validations:
+      required: false
+  - type: textarea
+    id: potential-causes-and-fixes
+    attributes:
+      label: Potential Causes and Fixes
+      description: |
+        Do you already know what could be causing this?
+        Any and all hints could be valuable.
+        Please provide us with what you know.
+      placeholder: Provide potential fixes, if known.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/02-feature-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature-proposal.yml
@@ -1,0 +1,44 @@
+name: Feature Proposal
+description: Propose a change or addition to `Rx`'s features.
+title: "[Feature Proposal]: "
+labels: ["feature proposal", "untriaged"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Feature proposals are very welcome! Please understand that not all proposals can be considered.
+        This template will help gather the information we need to start the review process.
+  - type: textarea
+    id: background-and-motivation
+    attributes:
+      label: Background and Motivation
+      description: |
+        Please describe the purpose and idea behind the new feature, as well as the value it will bring to you and other users.
+      placeholder: Describe the purpose.
+    validations:
+      required: true
+  - type: textarea
+    id: api-proposal
+    attributes:
+      label: API Proposal
+      description: |
+        If applicable, please provide the specific API signature(s) you are proposing.
+      placeholder: |
+        namespace Rx.Backend.SomeNamespace;
+
+        public class SomeController
+        {
+            public void SomeMethod();
+        }
+      render: csharp
+    validations:
+      required: false
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks
+      description: |
+        Please mention any risks that to your knowledge the proposal might entail, such as breaking changes, performance regressions, etc.
+      placeholder: Any potential risks?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/03-new-task.yml
+++ b/.github/ISSUE_TEMPLATE/03-new-task.yml
@@ -1,0 +1,49 @@
+name: New Task
+description: Creates a new mandatory task for us to implement.
+title: "[Task]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A task describes one small step towards a new implementation and is usually one part of a larger problem.
+  - type: input
+    id: parent-issue
+    attributes:
+      label: Parent Issue
+      description: |
+        If this task is part of a feature implementation, specify its issue number here.
+      value: >
+        #
+    validations:
+      required: false
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        Provide a detailed description of this task's purpose.
+        * When creating or editing an entity, describe all of its members.
+        * When creating or editing an API endpoint, specify the route, add request and response bodies, and specify all possible response codes.
+      placeholder: Describe the task.
+    validations:
+      required: true
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks
+      description: |
+        Specify all possible breaking changes or performance and security risks this task may introduce.
+      placeholder: Risks and breaking changes.
+    validations:
+      required: true
+  - type: textarea
+    id: related-issues
+    attributes:
+      label: Related Issues
+      description: |
+        Add any issues that this task is in relation to; bugs it may fix, other tasks it may depend on.
+      placeholder: |
+        - [ ] #
+    validations:
+      required: false
+

--- a/.github/ISSUE_TEMPLATE/04-new-feature.yml
+++ b/.github/ISSUE_TEMPLATE/04-new-feature.yml
@@ -1,0 +1,33 @@
+name: New Feature
+description: Creates a new feature issue for us to keep track of partial tasks in.
+title: "[Feature]: "
+body:
+  - type: textarea
+    id: overview
+    attributes:
+      label: Overview
+      description: |
+        Provide a summary of what this feature implements.
+      placeholder: Description and intended outcome.
+    validations:
+      required: true
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks
+      description: |
+        Collect all related tasks in a task list here.
+        Add more tasks as they get created.
+      value: |
+        - [ ] #
+    validations:
+      required: false
+  - type: textarea
+    id: future-ideas
+    attributes:
+      label: Future Ideas
+      description: |
+        Put any additional ideas you may have up for discussion.
+      placeholder: Future ideas.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/99-blank-issue.md
+++ b/.github/ISSUE_TEMPLATE/99-blank-issue.md
@@ -1,0 +1,4 @@
+---
+name: Blank Issue
+about: For when your issue doesn't fit the other templates.
+---

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Refunct Community Discord Server
+    url: https://discord.gg/refunct
+    about: Need help with Refunct-related issues? Join our friendly and helpful community of Refunct speedrunners.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+Addresses Issue # *(remove if not applicable)*
+
+# Description
+Describe what changes you are introducing or what task or feature you are implementing.
+
+# Risks
+If your changes are potentially implementing a breaking change or performance and security risks, please lay those out here.  
+Please also provide fixes where possible.


### PR DESCRIPTION
This PR introduces several GitHub issue templates and a pull request template.  
A preview of the templates can be seen on the `gh-templates` branch in the `.github` directory.

## Issue Templates
I have added templates for the below common topics. Additionally, each template includes several input fields a user can fill in. Required fields are marked with `*` for the sake of simplicity here.

* Bug Report
  * \* Description
  * \* Reproduction Steps
  * \* Version
  * Regression?
  * Potential Causes and Fixes

I am undecided on the formatting and existence of the `Regression?` and `Potential Causes and Fixes` entries. Looking for additional input.

* Feature Proposal
  * \* Background and Motivation
  * API Proposal
  * Risks

I am undecided on the `API Proposal` entry. Users that request features may not know what an API addition could look like. On top of that, not every feature request necessarily has to do with interacting with the API.

* New Task
  * Parent Issue
  * \* Description
  * \* Risks
  * Related Issues

A task is meant to describe a small unit of work; "Implement user registration", "Implement user login", etc.  
A new task issue should only be created by maintainers. I'm unsure of how to handle this. Perhaps we need to adjust the issue template's description.

* New Feature
  * \* Overview
  * Tasks
  * Future Ideas

A "feature" acts as a task list; a collection of tasks that must be completed before a new feature can be considered complete. A new feature may be proposed without a task having been created yet, hence why `Tasks` is not required. We can change this.

* Blank Issue

---

I have also added a config, which disables the "blank issue" default option from GitHub, because I find it difficult to spot. The config additionally creates a "contact link" which contains an invite to the Discord server.

## Pull Request Template
GitHub currently only allows exactly one PR template. This means it must be versatile. As of now, it only contains these sections:

* Issue
* Description
* Risks
* License Agreement

---
cc; @oberien, @DanTheChris for review.